### PR TITLE
full route and run arguments

### DIFF
--- a/perfume/__init__.py
+++ b/perfume/__init__.py
@@ -58,12 +58,15 @@ class Perfume(object):
         for name in dir(self):
             method = self.__getattribute__(name)
             try:
-                self.app.route(
-                    method.perfume_route,
-                    **method.perfume_args
-                    )(method)
+                method.perfume_route
+                method.perfume_args
             except AttributeError:
-                pass
+                continue
+
+            self.app.route(
+                method.perfume_route,
+                **method.perfume_args
+                )(method)
 
     def run(self):
         self.app.run()

--- a/perfume/__init__.py
+++ b/perfume/__init__.py
@@ -58,15 +58,12 @@ class Perfume(object):
         for name in dir(self):
             method = self.__getattribute__(name)
             try:
-                method.perfume_route
-                method.perfume_args
+                route = method.perfume_route
+                args = method.perfume_args
             except AttributeError:
                 continue
 
-            self.app.route(
-                method.perfume_route,
-                **method.perfume_args
-                )(method)
+            self.app.route(route, **args)(method)
 
     def run(self, *args, **kwds):
         self.app.run(*args, **kwds)

--- a/perfume/__init__.py
+++ b/perfume/__init__.py
@@ -36,10 +36,11 @@ __all__ = 'route', 'Perfume'
 from flask import Flask
 
 
-def route(regex):
+def route(regex, **kwds):
     'Decorates your function with a route as "function.perfume_route = ..."'
     def decorator(func):
         func.perfume_route = regex
+        func.perfume_args = kwds
         return func
     return decorator
 
@@ -57,7 +58,10 @@ class Perfume(object):
         for name in dir(self):
             method = self.__getattribute__(name)
             try:
-                self.app.route(method.perfume_route)(method)
+                self.app.route(
+                    method.perfume_route,
+                    **method.perfume_args
+                    )(method)
             except AttributeError:
                 pass
 

--- a/perfume/__init__.py
+++ b/perfume/__init__.py
@@ -37,9 +37,9 @@ from flask import Flask
 
 
 def route(regex):
-    'Decorates your function with a route as "function.route = ..."'
+    'Decorates your function with a route as "function.perfume_route = ..."'
     def decorator(func):
-        func.route = regex
+        func.perfume_route = regex
         return func
     return decorator
 
@@ -57,7 +57,7 @@ class Perfume(object):
         for name in dir(self):
             method = self.__getattribute__(name)
             try:
-                self.app.route(method.route)(method)
+                self.app.route(method.perfume_route)(method)
             except AttributeError:
                 pass
 

--- a/perfume/__init__.py
+++ b/perfume/__init__.py
@@ -68,7 +68,7 @@ class Perfume(object):
                 **method.perfume_args
                 )(method)
 
-    def run(self):
-        self.app.run()
+    def run(self, *args, **kwds):
+        self.app.run(*args, **kwds)
 
 


### PR DESCRIPTION
- route can accept parameters such as 'endpoint', 'method'...
- run can accept parameters such as 'host', 'port', 'debug'...
- AttributeErrors happening while decorating are not masked
- 'route' method attribute renamed as 'perfume_route' in order not try to wrap self.app because it also has a route attribute (method, indeed)
